### PR TITLE
Fix - Assets are uploaded as 34 byte

### DIFF
--- a/packages/automatic-releases/__tests__/assets/LICENSE
+++ b/packages/automatic-releases/__tests__/assets/LICENSE
@@ -1,0 +1,1 @@
+this should not be overridden

--- a/packages/automatic-releases/__tests__/utils.test.ts
+++ b/packages/automatic-releases/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import fs from 'fs';
-import {generateChangelogFromParsedCommits} from '../src/utils';
+import {generateChangelogFromParsedCommits, octokitLogger} from '../src/utils';
 
 describe('changelog generator', () => {
   beforeEach(() => {
@@ -74,5 +74,34 @@ describe('changelog generator', () => {
 
     const result = generateChangelogFromParsedCommits(payload);
     expect(result.trim()).toEqual(expected.trim());
+  });
+
+  it('log of input arguments should not overwrite the original args', () => {
+    const licenseFile = fs.readFileSync(path.join(__dirname, 'assets', 'LICENSE'), 'utf8');
+    const jarFile = fs.readFileSync(path.join(__dirname, 'assets', 'test.jar'), 'utf8');
+
+    const args = [
+      {
+        repoToken: 'repoToken',
+        automaticReleaseTag: 'automaticReleaseTag',
+        draftRelease: false,
+        preRelease: false,
+        releaseTitle: 'releaseTitle',
+        file: licenseFile,
+      },
+      {
+        repoToken: 'repoToken',
+        automaticReleaseTag: 'automaticReleaseTag',
+        draftRelease: false,
+        preRelease: false,
+        releaseTitle: 'releaseTitle',
+        file: jarFile,
+      },
+    ];
+
+    octokitLogger(...args);
+
+    expect(args[0].file).toEqual('this should not be overridden');
+    expect(args[1].file).toEqual('');
   });
 });

--- a/packages/automatic-releases/src/utils.ts
+++ b/packages/automatic-releases/src/utils.ts
@@ -168,15 +168,17 @@ export const octokitLogger = (...args): string => {
         return arg;
       }
 
+      const argCopy = {...arg};
+
       // Do not log file buffers
-      if (arg.file) {
-        arg.file = '== raw file buffer info removed ==';
+      if (argCopy.file) {
+        argCopy.file = '== raw file buffer info removed ==';
       }
-      if (arg.data) {
-        arg.data = '== raw file buffer info removed ==';
+      if (argCopy.data) {
+        argCopy.data = '== raw file buffer info removed ==';
       }
 
-      return JSON.stringify(arg);
+      return JSON.stringify(argCopy);
     })
     .reduce((acc, val) => `${acc} ${val}`, '');
 };


### PR DESCRIPTION
The `octokitLogger` function overwrote the file contents, to avoid that we make a defensive copy.

Close issue #10