### PR TITLE
Implement allow_duplicates

### DIFF
--- a/packages/automatic-releases/action.yml
+++ b/packages/automatic-releases/action.yml
@@ -22,6 +22,9 @@ inputs:
   files:
     description: "Assets to upload to the release"
     required: false
+  allow_duplicates:
+    description: "Indicates whether duplicate GitHub releases are allowed or not"
+    required: false
 outputs:
   automatic_releases_tag:
     decription: "The release tag this action just processed"


### PR DESCRIPTION
This PR tries to implement `allow_duplicates`. If I can get some pointers as to how I can implement at test for this, I think we should be all green.

It would also be nice to be able to test this "in real life" somehow before it's merged, I just need some help getting with how to get this temporarily available for another workflow.

Fixes #22.