### PR TITLE
[automatic-releases] Do not drop commits without known type

### DIFF
--- a/packages/automatic-releases/__tests__/payloads/parsed-commits-non-conforming-result.txt
+++ b/packages/automatic-releases/__tests__/payloads/parsed-commits-non-conforming-result.txt
@@ -1,2 +1,3 @@
 ## Commits
 - [[f6f40d9](https://github.com/octocat/Hello-World/commit/f6f40d9fbd1130f7f2357bb54225567dbd7a3793)]: Fix all the bugs (Monalisa Octocat)
+- [[a6f40d9](https://github.com/octocat/Hello-World/commit/a6f40d9fbd1130f7f2357bb54225567dbd7a3794)]: tests: Fix tests failures (Monalisa Octocat)

--- a/packages/automatic-releases/__tests__/payloads/parsed-commits-non-conforming.json
+++ b/packages/automatic-releases/__tests__/payloads/parsed-commits-non-conforming.json
@@ -93,5 +93,100 @@
       "pullRequests": [],
       "breakingChange": false
     }
+  },
+  {
+    "type": null,
+    "scope": null,
+    "subject": null,
+    "merge": null,
+    "header": "tests: Fix tests failures",
+    "body": null,
+    "footer": null,
+    "notes": [],
+    "references": [],
+    "mentions": [],
+    "revert": null,
+    "extra": {
+      "commit": {
+        "sha": "a6f40d9fbd1130f7f2357bb54225567dbd7a3794",
+        "node_id": "MDY6Q29tbWl0MjExNTU5MTQxOjQzOThlZjRlYTZmNWE2MTg4MGNhOTRlY2ZiOGU2MGQxYTM4NDk3ZGQ=",
+        "commit": {
+          "author": {
+            "name": "Monalisa Octocat",
+            "email": "support@github.com",
+            "date": "2011-04-14T16:00:49Z"
+          },
+          "committer": {
+            "name": "Monalisa Octocat",
+            "email": "support@github.com",
+            "date": "2011-04-14T16:00:49Z"
+          },
+          "message": "tests: Fix tests failures",
+          "tree": {
+            "sha": "a6f40d9fbd1130f7f2357bb54225567dbd7a3794",
+            "url": "https://api.github.com/repos/octocat/Hello-World/tree/a6f40d9fbd1130f7f2357bb54225567dbd7a3794"
+          },
+          "url": "https://api.github.com/repos/octocat/Hello-World/tree/a6f40d9fbd1130f7f2357bb54225567dbd7a3794",
+          "comment_count": 0,
+          "verification": {
+            "verified": false,
+            "reason": "unsigned",
+            "signature": null,
+            "payload": null
+          }
+        },
+        "url": "https://api.github.com/repos/octocat/Hello-World/commits/a6f40d9fbd1130f7f2357bb54225567dbd7a3794",
+        "html_url": "https://github.com/octocat/Hello-World/commit/a6f40d9fbd1130f7f2357bb54225567dbd7a3794",
+        "comments_url": "https://api.github.com/repos/octocat/Hello-World/commits/a6f40d9fbd1130f7f2357bb54225567dbd7a3794/comments",
+        "author": {
+          "login": "octocat",
+          "id": 1,
+          "node_id": "MDQ6VXNlcjE=",
+          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/octocat",
+          "html_url": "https://github.com/octocat",
+          "followers_url": "https://api.github.com/users/octocat/followers",
+          "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+          "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+          "organizations_url": "https://api.github.com/users/octocat/orgs",
+          "repos_url": "https://api.github.com/users/octocat/repos",
+          "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/octocat/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "committer": {
+          "login": "octocat",
+          "id": 1,
+          "node_id": "MDQ6VXNlcjE=",
+          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/octocat",
+          "html_url": "https://github.com/octocat",
+          "followers_url": "https://api.github.com/users/octocat/followers",
+          "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+          "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+          "organizations_url": "https://api.github.com/users/octocat/orgs",
+          "repos_url": "https://api.github.com/users/octocat/repos",
+          "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/octocat/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "parents": [
+          {
+            "url": "https://api.github.com/repos/octocat/Hello-World/commits/f6f40d9fbd1130f7f2357bb54225567dbd7a3793",
+            "sha": "f6f40d9fbd1130f7f2357bb54225567dbd7a3793"
+          }
+        ]
+      },
+      "pullRequests": [],
+      "breakingChange": false
+    }
   }
 ]

--- a/packages/automatic-releases/src/utils.ts
+++ b/packages/automatic-releases/src/utils.ts
@@ -130,7 +130,7 @@ export const generateChangelogFromParsedCommits = (parsedCommits: ParsedCommits[
 
   // Commits
   const commits = parsedCommits
-    .filter(val => val.type === null)
+    .filter(val => val.type === null || Object.keys(ConventionalCommitTypes).indexOf(val.type) === -1)
     .map(val => getFormattedChangelogEntry(val))
     .reduce((acc, line) => `${acc}\n${line}`, '');
   if (commits) {


### PR DESCRIPTION
Projects may have different conventions that those mandated by the
conventional-commits-parser[1] package. For example, it is customary
to also prefix commits depending on the area of change such as

src: fix foobar
tests: Fix another test

All these commits, when they are parsed, they end up with type == "src"
or type == "tests" and the package was dropping them silently because
they did not have a known type. However, we shouldn't do that but we
should let projects be flexible on how they use their commit messages
and simply list them along with those of type == null if they do not have a
known type.

[1] https://www.npmjs.com/package/conventional-commits-parser