### PR TITLE
fix: typo in action.yml

### DIFF
--- a/packages/automatic-releases/action.yml
+++ b/packages/automatic-releases/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
 outputs:
   automatic_releases_tag:
-    decription: "The release tag this action just processed"
+    description: "The release tag this action just processed"
 runs:
   using: "node12"
   main: "dist/index.js"


### PR DESCRIPTION
There is a key in action.yml that should be description but is in the file as decription.

This commit is a duplicate of PR #37 with the sole change of being a 'conventional commit'

Fixes #36