### PR TITLE
Better sha in changelog

### DIFF
--- a/packages/automatic-releases/src/utils.ts
+++ b/packages/automatic-releases/src/utils.ts
@@ -95,7 +95,7 @@ const getFormattedChangelogEntry = (parsedCommit: ParsedCommits): string => {
     prString = ' ' + prString;
   }
 
-  entry = `- [[${sha}](${url})]: ${parsedCommit.header} (${author})${prString}`;
+  entry = `- ${sha}: ${parsedCommit.header} (${author})${prString}`;
   if (parsedCommit.type) {
     const scopeStr = parsedCommit.scope ? `**${parsedCommit.scope}**: ` : '';
     entry = `- ${scopeStr}${parsedCommit.subject}${prString} ([${author}](${url}))`;


### PR DESCRIPTION
This generates a better looking changelog, and GitHub automatically links a hash (URL not required). Additionally, hovering on the hash produces a preview of the commit

## Before
- [[20e6cab](https://github.com/marvinpinto/actions/commit/20e6cabf4a2bdba4626f55c7096edde4dad1168e)]: chore(deps): bump actions/cache from v2.1.4 to v2.1.5

## After
- 20e6cab: chore(deps): bump actions/cache from v2.1.4 to v2.1.5

## Raw before/after

```
## Before
- [[20e6cab](https://github.com/marvinpinto/actions/commit/20e6cabf4a2bdba4626f55c7096edde4dad1168e)]: chore(deps): bump actions/cache from v2.1.4 to v2.1.5

## After
- 20e6cab: chore(deps): bump actions/cache from v2.1.4 to v2.1.5
```