### PR TITLE
Export the URL for uploading assets as the `upload_url` output

### DIFF
--- a/packages/automatic-releases/README.md
+++ b/packages/automatic-releases/README.md
@@ -109,6 +109,15 @@ jobs:
 | `title`                 | Release title; defaults to the tag name if none specified. | Tag Name |
 | `files`                 | Files to upload as part of the release assets.             | `null`   |
 
+## Outputs
+
+The following output values can be accessed via `${{ steps.<step-id>.outputs.<output-name> }}`:
+
+| Name                     | Description                                            | Type   |
+| ------------------------ | ------------------------------------------------------ | ------ |
+| `automatic_releases_tag` | The release tag this action just processed             | string |
+| `upload_url`             | The URL for uploading additional assets to the release | string |
+
 ### Notes:
 
 - Parameters denoted with `**` are required.

--- a/packages/automatic-releases/__tests__/automaticReleases.test.ts
+++ b/packages/automatic-releases/__tests__/automaticReleases.test.ts
@@ -125,9 +125,10 @@ describe('main handler processing automatic releases', () => {
     expect(core.exportVariable).toHaveBeenCalledTimes(1);
     expect(core.exportVariable).toHaveBeenCalledWith('AUTOMATIC_RELEASES_TAG', testInputAutomaticReleaseTag);
 
-    // Should output the releasetag
-    expect(core.setOutput).toHaveBeenCalledTimes(1);
+    // Should output the releasetag and the release upload url
+    expect(core.setOutput).toHaveBeenCalledTimes(2);
     expect(core.setOutput).toHaveBeenCalledWith('automatic_releases_tag', testInputAutomaticReleaseTag);
+    expect(core.setOutput).toHaveBeenCalledWith('upload_url', releaseUploadUrl);
   });
 
   it('should update an existing release tag', async () => {
@@ -218,8 +219,9 @@ describe('main handler processing automatic releases', () => {
     expect(core.exportVariable).toHaveBeenCalledTimes(1);
     expect(core.exportVariable).toHaveBeenCalledWith('AUTOMATIC_RELEASES_TAG', testInputAutomaticReleaseTag);
 
-    // Should output the releasetag
-    expect(core.setOutput).toHaveBeenCalledTimes(1);
+    // Should output the releasetag and the release upload url
+    expect(core.setOutput).toHaveBeenCalledTimes(2);
     expect(core.setOutput).toHaveBeenCalledWith('automatic_releases_tag', testInputAutomaticReleaseTag);
+    expect(core.setOutput).toHaveBeenCalledWith('upload_url', releaseUploadUrl);
   });
 });

--- a/packages/automatic-releases/action.yml
+++ b/packages/automatic-releases/action.yml
@@ -25,6 +25,8 @@ inputs:
 outputs:
   automatic_releases_tag:
     description: "The release tag this action just processed"
+  upload_url:
+    description: "The URL for uploading additional assets to the release"
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/packages/automatic-releases/src/main.ts
+++ b/packages/automatic-releases/src/main.ts
@@ -317,6 +317,7 @@ export const main = async (): Promise<void> => {
     core.debug(`Exporting environment variable AUTOMATIC_RELEASES_TAG with value ${releaseTag}`);
     core.exportVariable('AUTOMATIC_RELEASES_TAG', releaseTag);
     core.setOutput('automatic_releases_tag', releaseTag);
+    core.setOutput('upload_url', releaseUploadUrl);
   } catch (error) {
     core.setFailed(error.message);
     throw error;


### PR DESCRIPTION
Sometimes it may be useful to add additional assets to a created release afterwards (e.g. build multiple binaries for every supported platform and attach all of them to the same release). To make it possible, we just need to export the release upload URL as an output of the `automatic-releases` action.