### PR TITLE
fix(automatic-releases): the return value of "path.extname()" does not need to be processed

### DIFF
--- a/packages/automatic-releases/src/uploadReleaseArtifacts.ts
+++ b/packages/automatic-releases/src/uploadReleaseArtifacts.ts
@@ -39,7 +39,7 @@ export const uploadReleaseArtifacts = async (
         const hash = await md5File(filePath);
         const basename = path.basename(filePath, path.extname(filePath));
         const ext = path.extname(filePath);
-        const newName = ext ? `${basename}-${hash}.${ext}` : `${basename}-${hash}`;
+        const newName = `${basename}-${hash}${ext}`;
         await client.repos.uploadReleaseAsset({
           ...uploadArgs,
           name: newName,


### PR DESCRIPTION
We will get "`.`", "`.ext`" or "" (empty string) from `path.extname()` . Please see [`path.extname(path)` § Path | Node.js Documentation](https://nodejs.org/api/path.html#pathextnamepath).