### PR TITLE
fix(automatic-releases): remove empty file paths from "input.files"

### DIFF
--- a/packages/automatic-releases/src/main.ts
+++ b/packages/automatic-releases/src/main.ts
@@ -32,7 +32,7 @@ const getAndValidateArgs = (): Args => {
 
   const inputFilesStr = core.getInput('files', {required: false});
   if (inputFilesStr) {
-    args.files = inputFilesStr.split(/\r?\n/);
+    args.files = inputFilesStr.split(/\r?\n/).filter((path) => !/^\s*$/.test(path));
   }
 
   return args;


### PR DESCRIPTION
Compare:

```diff
  inputFilesStr: "file1.txt\nfile2.txt\n*.jar\n\n"
- args.files:    ["file1.txt","file2.txt","*.jar","",""]
+ args.files:    ["file1.txt","file2.txt","*.jar"]
```
