### PR TITLE
fix: handle spaces in the path to "node" executable

### DIFF
--- a/packages/automatic-releases/__tests__/automaticReleases-smoke.test.ts
+++ b/packages/automatic-releases/__tests__/automaticReleases-smoke.test.ts
@@ -27,7 +27,7 @@ describe('automatic releases smoke tests', () => {
     const mockHttp = mockNewReleaseTag.server.listen(httpPort);
     const bundle = await sanitizeEnvironment();
 
-    const node = which.sync('node')
+    const node = which.sync('node').replace(/ /g, '\\ ')
     const {stdout, stderr} = await exec(`${node} ${bundle}`, {
       cwd: os.tmpdir(),
       env: {
@@ -51,7 +51,7 @@ describe('automatic releases smoke tests', () => {
     const mockHttp = mockUpdateExistingTag.server.listen(httpPort);
     const bundle = await sanitizeEnvironment();
 
-    const node = which.sync('node')
+    const node = which.sync('node').replace(/ /g, '\\ ')
     const {stdout, stderr} = await exec(`${node} ${bundle}`, {
       cwd: os.tmpdir(),
       env: {

--- a/packages/automatic-releases/__tests__/taggedReleases-smoke.test.ts
+++ b/packages/automatic-releases/__tests__/taggedReleases-smoke.test.ts
@@ -26,7 +26,7 @@ describe('tagged releases smoke tests', () => {
     const mockHttp = mockNewTaggedRelease.server.listen(httpPort);
     const bundle = await sanitizeEnvironment();
 
-    const node = which.sync('node')
+    const node = which.sync('node').replace(/ /g, '\\ ')
     const {stdout, stderr} = await exec(`${node} ${bundle}`, {
       cwd: os.tmpdir(),
       env: {

--- a/packages/keybase-notifications/__tests__/main-smoke.test.ts
+++ b/packages/keybase-notifications/__tests__/main-smoke.test.ts
@@ -26,7 +26,7 @@ describe('main handler smoke tests', () => {
     const mockHttp = mockSuccessBuildMsg.server.listen(httpPort);
     const bundle = await sanitizeEnvironment();
 
-    const node = which.sync('node')
+    const node = which.sync('node').replace(/ /g, '\\ ')
     const {stdout, stderr} = await exec(`${node} ${bundle}`, {
       cwd: os.tmpdir(),
       env: {


### PR DESCRIPTION
Original:

```console
$ which node && node -e \
> '
>   require("child_process").exec(
>     require("which").sync("node")                      + " --version",
>     {},
>     (err, stdout) => {
>       if (err) throw err;
>       console.log(stdout);
>     },
>   )
> '
/home/test-nvm-with-spaces/ s p a c e /versions/node/v10.24.1/bin/node
[eval]:6
      if (err) throw err;
               ^

Error: Command failed: /home/test-nvm-with-spaces/ s p a c e /versions/node/v10.24.1/bin/node --version
/bin/sh: 1: /home/test-nvm-with-spaces/: Permission denied

```

New:

```console
$ which node && node -e \
> '
>   require("child_process").exec(
>     require("which").sync("node").replace(/ /g, "\\ ") + " --version",
>     {},
>     (err, stdout) => {
>       if (err) throw err;
>       console.log(stdout);
>     },
>   )
> '
/home/test-nvm-with-spaces/ s p a c e /versions/node/v10.24.1/bin/node
v10.24.1

```

Diff:

```diff
- require("which").sync("node")                      + " --version",
+ require("which").sync("node").replace(/ /g, "\\ ") + " --version",
```