### PR TITLE
feat(automatic-releases): don't call "uploadReleaseArtifacts()" if no "files" are specified

### DIFF
--- a/packages/automatic-releases/__tests__/automaticReleases.test.ts
+++ b/packages/automatic-releases/__tests__/automaticReleases.test.ts
@@ -53,7 +53,7 @@ describe('main handler processing automatic releases', () => {
     );
   });
 
-  it('should create a new release tag', async () => {
+  it('should create a new release tag w/o artifacts', async () => {
     delete process.env.INPUT_FILES;
     const releaseUploadUrl = 'https://releaseupload.example.com';
     const compareCommitsPayload = JSON.parse(
@@ -116,10 +116,8 @@ describe('main handler processing automatic releases', () => {
     expect(getCommitsSinceRelease.isDone()).toBe(true);
     expect(listAssociatedPRs.isDone()).toBe(true);
 
-    expect(uploadReleaseArtifacts).toHaveBeenCalledTimes(1);
-    expect(uploadReleaseArtifacts.mock.calls[0][1]).toBe(releaseUploadUrl);
     // Should not attempt to upload any release artifacts, as there are none
-    expect(uploadReleaseArtifacts.mock.calls[0][2]).toEqual([]);
+    expect(uploadReleaseArtifacts).toHaveBeenCalledTimes(0);
 
     // Should populate the output env variable
     expect(core.exportVariable).toHaveBeenCalledTimes(1);

--- a/packages/automatic-releases/src/main.ts
+++ b/packages/automatic-releases/src/main.ts
@@ -312,7 +312,7 @@ export const main = async (): Promise<void> => {
       body: changelog,
     });
 
-    await uploadReleaseArtifacts(client, releaseUploadUrl, args.files);
+    if (args.files.length !== 0) await uploadReleaseArtifacts(client, releaseUploadUrl, args.files);
 
     core.debug(`Exporting environment variable AUTOMATIC_RELEASES_TAG with value ${releaseTag}`);
     core.exportVariable('AUTOMATIC_RELEASES_TAG', releaseTag);


### PR DESCRIPTION
This is another way to achieve #373 .