### PR TITLE
fix(automatic-releases): throw errors if none of the glob patterns in "input.files" match any files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,7 +45,6 @@ module.exports = {
     '!**/packages/keybase-notifications/src/index.ts',
     '!**/packages/keybase-notifications/src/utils.ts',
     '!**/packages/automatic-releases/src/index.ts',
-    '!**/packages/automatic-releases/src/uploadReleaseArtifacts.ts',
     '!**/packages/aws-ssm-secrets/src/index.ts',
   ],
 };

--- a/packages/automatic-releases/__tests__/uploadReleaseArtifacts.test.ts
+++ b/packages/automatic-releases/__tests__/uploadReleaseArtifacts.test.ts
@@ -1,0 +1,212 @@
+import path from 'path';
+import {lstatSync, readFileSync} from 'fs';
+import md5File from 'md5-file';
+
+const releaseUploadUrl = 'https://releaseupload.example.com';
+
+const constructUploadArgs = (filePath: string, releaseUploadUrl: string) => ({
+  url: releaseUploadUrl,
+  headers: {
+    'content-length': lstatSync(filePath).size,
+    'content-type': 'application/octet-stream',
+  },
+  name: path.basename(filePath),
+  file: readFileSync(filePath),
+});
+
+const constructUploadArgsWithMd5 = async (filePath: string, releaseUploadUrl: string) => {
+  const ext = path.extname(filePath);
+  const basename = path.basename(filePath, ext);
+  const hash = await md5File(filePath);
+  return {
+    ...constructUploadArgs(filePath, releaseUploadUrl),
+    name: `${basename}-${hash}${ext}`,
+  };
+};
+
+describe('uploadReleaseArtifacts handler', () => {
+  describe('when processing various file lists', () => {
+    let github: any;
+    let core: any;
+    let uploadReleaseArtifacts: any;
+
+    beforeAll(() => {
+      jest.resetModules();
+
+      jest.doMock('@actions/github', () => {
+        const module = jest.createMockFromModule<any>('@actions/github');
+        module.GitHub.prototype.repos.uploadReleaseAsset = jest.fn();
+        return module;
+      });
+      jest.doMock('@actions/core', () => ({
+        ...jest.createMockFromModule<any>('@actions/core'),
+        error: jest.fn(),
+      }));
+
+      github = require('@actions/github');
+      core = require('@actions/core');
+      ({uploadReleaseArtifacts} = require('../src/uploadReleaseArtifacts'));
+    });
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should upload nothing, if "input.files" is ["assets/*.txt", "assets/*.md"]', async () => {
+      const testInputFiles = [
+        path.join(__dirname, 'assets/*.txt'),
+        path.join(__dirname, 'assets/*.md'),
+      ];
+      const missingFiles = [
+        path.join(__dirname, 'assets/*.txt'),
+        path.join(__dirname, 'assets/*.md'),
+      ];
+
+      await uploadReleaseArtifacts(new github.GitHub(undefined), releaseUploadUrl, testInputFiles);
+
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset).toHaveBeenCalledTimes(0);
+
+      expect(core.error).toHaveBeenCalledTimes(2);
+      expect(core.error.mock.calls[0][0]).toStrictEqual(`${missingFiles[0]} doesn't match any files`);
+      expect(core.error.mock.calls[1][0]).toStrictEqual(`${missingFiles[1]} doesn't match any files`);
+    });
+
+    it('should upload "LICENSE", if "input.files" is ["assets/*.txt", "assets/LICENSE"]', async () => {
+      const testInputFiles = [
+        path.join(__dirname, 'assets/*.txt'),
+        path.join(__dirname, 'assets/LICENSE'),
+      ];
+      const actualFoundFiles = [
+        path.join(__dirname, 'assets/LICENSE'),
+      ];
+      const missingFiles = [
+        path.join(__dirname, 'assets/*.txt'),
+      ];
+
+      await uploadReleaseArtifacts(new github.GitHub(undefined), releaseUploadUrl, testInputFiles);
+
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset).toHaveBeenCalledTimes(1);
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset.mock.calls[0][0]).toStrictEqual(constructUploadArgs(actualFoundFiles[0], releaseUploadUrl));
+
+      expect(core.error).toHaveBeenCalledTimes(1);
+      expect(core.error.mock.calls[0][0]).toStrictEqual(`${missingFiles[0]} doesn't match any files`);
+    });
+
+    it('should upload "LICENSE", if "input.files" is ["assets/LICENSE", "assets/*.txt"]', async () => {
+      const testInputFiles = [
+        path.join(__dirname, 'assets/LICENSE'),
+        path.join(__dirname, 'assets/*.txt'),
+      ];
+      const actualFoundFiles = [
+        path.join(__dirname, 'assets/LICENSE'),
+      ];
+      const missingFiles = [
+        path.join(__dirname, 'assets/*.txt'),
+      ];
+
+      await uploadReleaseArtifacts(new github.GitHub(undefined), releaseUploadUrl, testInputFiles);
+
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset).toHaveBeenCalledTimes(1);
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset.mock.calls[0][0]).toStrictEqual(constructUploadArgs(actualFoundFiles[0], releaseUploadUrl));
+
+      expect(core.error).toHaveBeenCalledTimes(1);
+      expect(core.error.mock.calls[0][0]).toStrictEqual(`${missingFiles[0]} doesn't match any files`);
+    });
+
+    it('should upload "LICENSE" and "test.jar", if "input.files" is ["assets/LICENSE", "assets/*.jar"]', async () => {
+      const testInputFiles = [
+        path.join(__dirname, 'assets/LICENSE'),
+        path.join(__dirname, 'assets/*.jar'),
+      ];
+      const actualFoundFiles = [
+        path.join(__dirname, 'assets/LICENSE'),
+        path.join(__dirname, 'assets/test.jar'),
+      ];
+
+      await uploadReleaseArtifacts(new github.GitHub(undefined), releaseUploadUrl, testInputFiles);
+
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset).toHaveBeenCalledTimes(2);
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset.mock.calls[0][0]).toStrictEqual(constructUploadArgs(actualFoundFiles[0], releaseUploadUrl));
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset.mock.calls[1][0]).toStrictEqual(constructUploadArgs(actualFoundFiles[1], releaseUploadUrl));
+
+      expect(core.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should upload "LICENSE" and "test.jar", if "input.files" is ["assets/*"]', async () => {
+      const testInputFiles = [
+        path.join(__dirname, 'assets/*'),
+      ];
+      const actualFoundFiles = [
+        path.join(__dirname, 'assets/LICENSE'),
+        path.join(__dirname, 'assets/test.jar'),
+      ];
+
+      await uploadReleaseArtifacts(new github.GitHub(undefined), releaseUploadUrl, testInputFiles);
+
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset).toHaveBeenCalledTimes(2);
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset.mock.calls[0][0]).toStrictEqual(constructUploadArgs(actualFoundFiles[0], releaseUploadUrl));
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset.mock.calls[1][0]).toStrictEqual(constructUploadArgs(actualFoundFiles[1], releaseUploadUrl));
+
+      expect(core.error).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('when "client.repos.uploadReleaseAsset()" fails 1 time per file', () => {
+    let github: any;
+    let core: any;
+    let uploadReleaseArtifacts: any;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.resetModules();
+
+      jest.doMock('@actions/github', () => {
+        const module = jest.createMockFromModule<any>('@actions/github');
+        module.GitHub.prototype.repos.uploadReleaseAsset = jest
+          .fn()
+          .mockRejectedValueOnce(new Error('upload failed 0'))
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error('upload failed 1'))
+          .mockResolvedValueOnce(undefined);
+        return module;
+      });
+      jest.doMock('@actions/core', () => ({
+        ...jest.createMockFromModule<any>('@actions/core'),
+        info: jest.fn(),
+      }));
+
+      github = require('@actions/github');
+      core = require('@actions/core');
+      ({uploadReleaseArtifacts} = require('../src/uploadReleaseArtifacts'));
+    });
+
+    it('should retry to upload "LICENSE" and "test.jar" with md5 hash appended', async () => {
+      const testInputFiles = [
+        path.join(__dirname, 'assets/LICENSE'),
+        path.join(__dirname, 'assets/test.jar'),
+      ];
+
+      await uploadReleaseArtifacts(new github.GitHub(undefined), releaseUploadUrl, testInputFiles);
+
+      expect(core.info).toHaveBeenCalledTimes(4);
+      expect(core.info.mock.calls[0][0]).toStrictEqual(
+        `Uploading: ${testInputFiles[0]}`
+      );
+      expect(core.info.mock.calls[1][0]).toStrictEqual(
+        `Problem uploading ${testInputFiles[0]} as a release asset (${'upload failed 0'}). Will retry with the md5 hash appended to the filename.`
+      );
+      expect(core.info.mock.calls[2][0]).toStrictEqual(
+        `Uploading: ${testInputFiles[1]}`
+      );
+      expect(core.info.mock.calls[3][0]).toStrictEqual(
+        `Problem uploading ${testInputFiles[1]} as a release asset (${'upload failed 1'}). Will retry with the md5 hash appended to the filename.`
+      );
+
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset).toHaveBeenCalledTimes(4);
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset.mock.calls[0][0]).toStrictEqual(constructUploadArgs(testInputFiles[0], releaseUploadUrl));
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset.mock.calls[1][0]).toStrictEqual(await constructUploadArgsWithMd5(testInputFiles[0], releaseUploadUrl));
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset.mock.calls[2][0]).toStrictEqual(constructUploadArgs(testInputFiles[1], releaseUploadUrl));
+      expect(github.GitHub.prototype.repos.uploadReleaseAsset.mock.calls[3][0]).toStrictEqual(await constructUploadArgsWithMd5(testInputFiles[1], releaseUploadUrl));
+    });
+  });
+});

--- a/packages/automatic-releases/__tests__/uploadReleaseArtifacts.test.ts
+++ b/packages/automatic-releases/__tests__/uploadReleaseArtifacts.test.ts
@@ -52,7 +52,7 @@ describe('uploadReleaseArtifacts handler', () => {
       jest.clearAllMocks();
     });
 
-    it('should upload nothing, if "input.files" is ["assets/*.txt", "assets/*.md"]', async () => {
+    it('throws as nothing found, if "input.files" is ["assets/*.txt", "assets/*.md"]', async () => {
       const testInputFiles = [
         path.join(__dirname, 'assets/*.txt'),
         path.join(__dirname, 'assets/*.md'),
@@ -62,7 +62,9 @@ describe('uploadReleaseArtifacts handler', () => {
         path.join(__dirname, 'assets/*.md'),
       ];
 
-      await uploadReleaseArtifacts(new github.GitHub(undefined), releaseUploadUrl, testInputFiles);
+      await expect(uploadReleaseArtifacts(new github.GitHub(undefined), releaseUploadUrl, testInputFiles)).rejects.toThrow(
+        `No file matched by the glob pattern: ["${missingFiles[0]}", "${missingFiles[1]}"]`,
+      );
 
       expect(github.GitHub.prototype.repos.uploadReleaseAsset).toHaveBeenCalledTimes(0);
 

--- a/packages/automatic-releases/src/uploadReleaseArtifacts.ts
+++ b/packages/automatic-releases/src/uploadReleaseArtifacts.ts
@@ -11,11 +11,14 @@ export const uploadReleaseArtifacts = async (
   files: string[],
 ): Promise<void> => {
   core.startGroup('Uploading release artifacts');
+  let noFileFound = true;
   for (const fileGlob of files) {
     const paths = await globby(fileGlob);
     if (paths.length == 0) {
       core.error(`${fileGlob} doesn't match any files`);
+      continue;
     }
+    noFileFound = false;
 
     for (const filePath of paths) {
       core.info(`Uploading: ${filePath}`);
@@ -46,6 +49,9 @@ export const uploadReleaseArtifacts = async (
         });
       }
     }
+  }
+  if (noFileFound) {
+    throw new Error(`No file matched by the glob pattern: [${files.map((pattern) => '"' + pattern + '"').join(', ')}]`);
   }
   core.endGroup();
 };

--- a/packages/automatic-releases/webpack.config.js
+++ b/packages/automatic-releases/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = {
   },
 
   optimization: {
-    minimize: true,
+    minimize: false,
     minimizer: [
       new TerserPlugin({
         terserOptions: {


### PR DESCRIPTION
Re fix #62 .

#63 is not complete. [`core.error()`](https://github.com/actions/toolkit/blob/243a8bba07ca25564b20bc359db606fbe82edaec/packages/core/README.md#logging) just did logging, so the error handling code at [main.ts#L322-L323](https://github.com/marvinpinto/actions/blob/9ecff5f61cbff8b2d81c3a064cb805931e730fdd/packages/automatic-releases/src/main.ts#L322-L323) would not work.  
I think that if a user wants to upload something that doesn't exist, they should encounter an error severe enough to bring the workflow down.

I come from https://github.com/miurahr/aqtinstall/discussions/404#discussioncomment-1385519 .

This makes smoke tests failed. We need to merge #380 first.
