### PR TITLE
chore: tsconfig.json: "rootDir" should be in "compilerOptions"

### DIFF
--- a/packages/automatic-releases/tsconfig.json
+++ b/packages/automatic-releases/tsconfig.json
@@ -1,4 +1,6 @@
 {
   "extends": "../../tsconfig-base",
-  "rootDir": "./src"
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }

--- a/packages/aws-ssm-secrets/tsconfig.json
+++ b/packages/aws-ssm-secrets/tsconfig.json
@@ -1,4 +1,6 @@
 {
   "extends": "../../tsconfig-base",
-  "rootDir": "./src"
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }

--- a/packages/keybase-notifications/tsconfig.json
+++ b/packages/keybase-notifications/tsconfig.json
@@ -1,4 +1,6 @@
 {
   "extends": "../../tsconfig-base",
-  "rootDir": "./src"
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }


### PR DESCRIPTION
VS Code's TS engine told me this.

See also: [TypeScript: TSConfig Reference - Docs on every TSConfig option](https://www.typescriptlang.org/tsconfig)