### PR TITLE
include 'changelog_file'-option to specify a ChangeLog file

### DIFF
--- a/packages/automatic-releases/README.md
+++ b/packages/automatic-releases/README.md
@@ -100,14 +100,15 @@ jobs:
 
 ## Supported Parameters
 
-| Parameter               | Description                                                | Default  |
-| ----------------------- | ---------------------------------------------------------- | -------- |
-| `repo_token`\*\*        | GitHub Action token, e.g. `"${{ secrets.GITHUB_TOKEN }}"`. | `null`   |
-| `draft`                 | Mark this release as a draft?                              | `false`  |
-| `prerelease`            | Mark this release as a pre-release?                        | `true`   |
-| `automatic_release_tag` | Tag name to use for automatic releases, e.g `latest`.      | `null`   |
-| `title`                 | Release title; defaults to the tag name if none specified. | Tag Name |
-| `files`                 | Files to upload as part of the release assets.             | `null`   |
+| Parameter               | Description                                                                   | Default  |
+| ----------------------- | ----------------------------------------------------------------------------- | -------- |
+| `repo_token`\*\*        | GitHub Action token, e.g. `"${{ secrets.GITHUB_TOKEN }}"`.                    | `null`   |
+| `draft`                 | Mark this release as a draft?                                                 | `false`  |
+| `prerelease`            | Mark this release as a pre-release?                                           | `true`   |
+| `automatic_release_tag` | Tag name to use for automatic releases, e.g `latest`.                         | `null`   |
+| `title`                 | Release title; defaults to the tag name if none specified.                    | Tag Name |
+| `files`                 | Files to upload as part of the release assets.                                | `null`   |
+| `changelog_file`        | Text you want to put in the release/changelog info. (Disables auto changelog) | `null`   |
 
 ## Outputs
 

--- a/packages/automatic-releases/__tests__/payloads/changelog-file.txt
+++ b/packages/automatic-releases/__tests__/payloads/changelog-file.txt
@@ -1,0 +1,6 @@
+This is a test changelog
+
+- we did that
+- and we fixed this
+- this feature is new
+- this feature is deprecated

--- a/packages/automatic-releases/__tests__/utils.test.ts
+++ b/packages/automatic-releases/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import fs from 'fs';
-import {generateChangelogFromParsedCommits, octokitLogger} from '../src/utils';
+import {getChangelog, generateChangelogFromParsedCommits, octokitLogger} from '../src/utils';
 
 describe('changelog generator', () => {
   beforeEach(() => {
@@ -103,5 +103,13 @@ describe('changelog generator', () => {
 
     expect(args[0].file).toEqual('this should not be overridden');
     expect(args[1].file).toEqual('');
+  });
+
+  it('check if a changelog can be read from file', () => {
+    const changeLogFile = path.join(__dirname, 'payloads', 'changelog-file.txt');
+    const expected = fs.readFileSync(changeLogFile, 'utf8');
+    return getChangelog(null, null, null, null, changeLogFile).then(result => {
+      expect(result.trim()).toEqual(expected.trim());
+    });
   });
 });

--- a/packages/automatic-releases/action.yml
+++ b/packages/automatic-releases/action.yml
@@ -22,6 +22,9 @@ inputs:
   files:
     description: "Assets to upload to the release"
     required: false
+  changelog_file:
+    description: "Text you want to put in the release/changelog info. (Disables auto changelog)"
+    required: false
 outputs:
   automatic_releases_tag:
     description: "The release tag this action just processed"

--- a/packages/automatic-releases/src/main.ts
+++ b/packages/automatic-releases/src/main.ts
@@ -16,6 +16,7 @@ type Args = {
   preRelease: boolean;
   releaseTitle: string;
   files: string[];
+  changeLogFile: string;
 };
 
 const getAndValidateArgs = (): Args => {
@@ -26,6 +27,7 @@ const getAndValidateArgs = (): Args => {
     preRelease: JSON.parse(core.getInput('prerelease', {required: true})),
     releaseTitle: core.getInput('title', {required: false}),
     files: [] as string[],
+    changeLogFile: core.getInput('changelog_file', {required: false}),
   };
 
   const inputFilesStr = core.getInput('files', {required: false});
@@ -223,7 +225,13 @@ export const main = async (): Promise<void> => {
       context.sha,
     );
 
-    const changelog = await getChangelog(client, context.repo.owner, context.repo.repo, commitsSinceRelease);
+    const changelog = await getChangelog(
+      client,
+      context.repo.owner,
+      context.repo.repo,
+      commitsSinceRelease,
+      args.changeLogFile,
+    );
 
     if (args.automaticReleaseTag) {
       await createReleaseTag(client, {

--- a/packages/automatic-releases/src/utils.ts
+++ b/packages/automatic-releases/src/utils.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core';
 import {sync as commitParser} from 'conventional-commits-parser';
+import * as fs from 'fs';
 import * as github from '@actions/github';
 import * as Octokit from '@octokit/rest';
 import defaultChangelogOpts from 'conventional-changelog-angular/conventional-recommended-bump';
@@ -196,9 +197,14 @@ export const getChangelog = async (
   owner: string,
   repo: string,
   commits: Octokit.ReposCompareCommitsResponseCommitsItem[],
+  changeLogFile: string,
 ): Promise<string> => {
   const parsedCommits: ParsedCommits[] = [];
   core.startGroup('Generating changelog');
+
+  if (changeLogFile) {
+    return fs.readFileSync(changeLogFile, 'utf8');
+  }
 
   for (const commit of commits) {
     core.debug(`Processing commit: ${JSON.stringify(commit)}`);


### PR DESCRIPTION
I want to provide my own ChangeLog instead of the generated one.

- With this PR you can specify `changelog_file: customChangeLogFile` which will replace the generated changeLog
- if option is not set, the generated changelog will be used