### PR TITLE
feat: add support for GitHub automatic release notes generation

### DIFF
--- a/packages/automatic-releases/__tests__/automaticReleases.test.ts
+++ b/packages/automatic-releases/__tests__/automaticReleases.test.ts
@@ -17,6 +17,7 @@ describe('main handler processing automatic releases', () => {
   const testInputTitle = 'Development Build';
   const testInputBody = `## Commits\n- f6f40d9: Fix all the bugs (Monalisa Octocat)`;
   const testInputFiles = 'file1.txt\nfile2.txt\n*.jar\n\n';
+  const testInputAutoGenerateReleaseNotes = false;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -27,6 +28,7 @@ describe('main handler processing automatic releases', () => {
     process.env['INPUT_PRERELEASE'] = testInputPrerelease.toString();
     process.env['INPUT_TITLE'] = testInputTitle;
     process.env['INPUT_FILES'] = testInputFiles;
+    process.env['INPUT_AUTO_GENERATE_RELEASE_NOTES'] = testInputAutoGenerateReleaseNotes.toString();
 
     process.env['GITHUB_EVENT_NAME'] = 'push';
     process.env['GITHUB_SHA'] = testGhSHA;
@@ -93,14 +95,15 @@ describe('main handler processing automatic releases', () => {
       .delete(/.*/)
       .reply(200);
 
-    const createRelease = nock('https://api.github.com')
-      .matchHeader('authorization', `token ${testGhToken}`)
-      .post('/repos/marvinpinto/private-actions-tester/releases', {
+    const createRelease = nock("https://api.github.com")
+      .matchHeader("authorization", `token ${testGhToken}`)
+      .post("/repos/marvinpinto/private-actions-tester/releases", {
         tag_name: testInputAutomaticReleaseTag,
         name: testInputTitle,
         draft: testInputDraft,
         prerelease: testInputPrerelease,
         body: testInputBody,
+        generate_release_notes: testInputAutoGenerateReleaseNotes,
       })
       .reply(200, {
         upload_url: releaseUploadUrl,
@@ -195,6 +198,7 @@ describe('main handler processing automatic releases', () => {
         draft: testInputDraft,
         prerelease: testInputPrerelease,
         body: testInputBody,
+        generate_release_notes: testInputAutoGenerateReleaseNotes,
       })
       .reply(200, {
         upload_url: releaseUploadUrl,

--- a/packages/automatic-releases/__tests__/taggedReleases.test.ts
+++ b/packages/automatic-releases/__tests__/taggedReleases.test.ts
@@ -15,6 +15,7 @@ describe('main handler processing tagged releases', () => {
   const testInputPrerelease = false;
   const testInputBody = `## Commits\n- f6f40d9: Fix all the bugs (Monalisa Octocat)`;
   const testInputFiles = 'file1.txt\nfile2.txt\n*.jar\n\n';
+  const testInputAutoGenerateReleaseNotes = false;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -23,6 +24,7 @@ describe('main handler processing tagged releases', () => {
     process.env['INPUT_DRAFT'] = testInputDraft.toString();
     process.env['INPUT_PRERELEASE'] = testInputPrerelease.toString();
     process.env['INPUT_FILES'] = testInputFiles;
+    process.env['INPUT_AUTO_GENERATE_RELEASE_NOTES'] = testInputAutoGenerateReleaseNotes.toString();
 
     process.env['GITHUB_EVENT_NAME'] = 'push';
     process.env['GITHUB_SHA'] = testGhSHA;
@@ -103,14 +105,15 @@ describe('main handler processing tagged releases', () => {
       .get(`/repos/marvinpinto/private-actions-tester/commits/${testGhSHA}/pulls`)
       .reply(200, []);
 
-    const createRelease = nock('https://api.github.com')
-      .matchHeader('authorization', `token ${testGhToken}`)
-      .post('/repos/marvinpinto/private-actions-tester/releases', {
-        tag_name: 'v0.0.1',
-        name: 'v0.0.1',
+    const createRelease = nock("https://api.github.com")
+      .matchHeader("authorization", `token ${testGhToken}`)
+      .post("/repos/marvinpinto/private-actions-tester/releases", {
+        tag_name: "v0.0.1",
+        name: "v0.0.1",
         draft: testInputDraft,
         prerelease: testInputPrerelease,
         body: testInputBody,
+        generate_release_notes: testInputAutoGenerateReleaseNotes,
       })
       .reply(200, {
         upload_url: releaseUploadUrl,

--- a/packages/automatic-releases/__tests__/utils/mockNewReleaseTag.ts
+++ b/packages/automatic-releases/__tests__/utils/mockNewReleaseTag.ts
@@ -11,6 +11,7 @@ const testInputDraft = false;
 const testInputPrerelease = true;
 const testInputTitle = 'Development Build';
 const testInputFiles = 'file1.txt\nfile2.txt\n*.jar\n\n';
+const testInputAutoGenerateReleaseNotes = false;
 
 server.get(`/repos/marvinpinto/private-actions-tester/compare/HEAD...${testGhSHA}`, (req, res) => {
   const compareCommitsPayload = JSON.parse(
@@ -49,6 +50,7 @@ export const setupEnv = {
   INPUT_PRERELEASE: testInputPrerelease.toString(),
   INPUT_TITLE: testInputTitle,
   INPUT_FILES: testInputFiles,
+  INPUT_AUTO_GENERATE_RELEASE_NOTES: testInputAutoGenerateReleaseNotes.toString(),
 
   GITHUB_EVENT_NAME: 'push',
   GITHUB_SHA: testGhSHA,

--- a/packages/automatic-releases/__tests__/utils/mockNewTaggedRelease.ts
+++ b/packages/automatic-releases/__tests__/utils/mockNewTaggedRelease.ts
@@ -9,6 +9,7 @@ const testGhSHA = 'f6f40d9fbd1130f7f2357bb54225567dbd7a3793';
 const testInputDraft = false;
 const testInputPrerelease = true;
 const testInputFiles = 'file1.txt\nfile2.txt\n*.jar\n\n';
+const testInputAutoGenerateReleaseNotes = false;
 
 server.get(`/repos/marvinpinto/private-actions-tester/tags`, (req, res) => {
   res.json([
@@ -65,6 +66,7 @@ export const setupEnv = {
   INPUT_DRAFT: testInputDraft.toString(),
   INPUT_PRERELEASE: testInputPrerelease.toString(),
   INPUT_FILES: testInputFiles,
+  INPUT_AUTO_GENERATE_RELEASE_NOTES: testInputAutoGenerateReleaseNotes.toString(),
 
   GITHUB_EVENT_NAME: 'push',
   GITHUB_SHA: testGhSHA,

--- a/packages/automatic-releases/__tests__/utils/mockUpdateExistingTag.ts
+++ b/packages/automatic-releases/__tests__/utils/mockUpdateExistingTag.ts
@@ -11,6 +11,7 @@ const testInputDraft = false;
 const testInputPrerelease = true;
 const testInputTitle = 'Development Build';
 const testInputFiles = 'file1.txt\nfile2.txt\n*.jar\n\n';
+const testInputAutoGenerateReleaseNotes = false;
 
 const previousReleaseSHA = '4398ef4ea6f5a61880ca94ecfb8e60d1a38497dd';
 const foundReleaseId = 1235523222;
@@ -67,6 +68,7 @@ export const setupEnv = {
   INPUT_PRERELEASE: testInputPrerelease.toString(),
   INPUT_TITLE: testInputTitle,
   INPUT_FILES: testInputFiles,
+  INPUT_AUTO_GENERATE_RELEASE_NOTES: testInputAutoGenerateReleaseNotes.toString(),
 
   GITHUB_EVENT_NAME: 'push',
   GITHUB_SHA: testGhSHA,

--- a/packages/automatic-releases/action.yml
+++ b/packages/automatic-releases/action.yml
@@ -22,6 +22,10 @@ inputs:
   files:
     description: "Assets to upload to the release"
     required: false
+  auto_generate_release_notes:
+    description: "Let GitHub generate release notes automatically"
+    required: false
+    default: false
 outputs:
   automatic_releases_tag:
     description: "The release tag this action just processed"

--- a/packages/automatic-releases/package.json
+++ b/packages/automatic-releases/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "2.0.0",
-    "@octokit/rest": "16.36.0",
+    "@octokit/rest": "^18.12.0",
+    "@octokit/types": "^6.34.0",
     "conventional-changelog-angular": "^5.0.12",
     "conventional-commits-parser": "^3.2.0",
     "globby": "^11.0.1",

--- a/packages/keybase-notifications/src/utils.ts
+++ b/packages/keybase-notifications/src/utils.ts
@@ -28,5 +28,5 @@ export const dumpGitHubEventPayload = (): void => {
   }
   const contents = fs.readFileSync(ghpath, 'utf8');
   const jsonContent = JSON.parse(contents);
-  core.info(`GitHub payload: ${JSON.stringify(jsonContent)}`);
+  core.debug(`GitHub payload: ${JSON.stringify(jsonContent)}`);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,6 +2071,19 @@
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/core@^3.5.1":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.6.0.tgz#3376cb9f3008d9b3d110370d90e0a1fcd5fe6085"
+  integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.6.3"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/endpoint@^5.1.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.4.0.tgz#5b44b3e8e92d88765daf127e1501174ecbca7bce"
@@ -2115,6 +2128,11 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
+"@octokit/openapi-types@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
+  integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
+
 "@octokit/openapi-types@^5.3.2":
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-5.3.2.tgz#b8ac43c5c3d00aef61a34cf744e315110c78deb4"
@@ -2124,6 +2142,13 @@
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-6.0.1.tgz#e07896739618dab8da7d4077c658003775f95437"
   integrity sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw==
+
+"@octokit/plugin-paginate-rest@^2.16.8":
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz#32e9c7cab2a374421d3d0de239102287d791bce7"
+  integrity sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==
+  dependencies:
+    "@octokit/types" "^6.34.0"
 
 "@octokit/plugin-paginate-rest@^2.6.2":
   version "2.13.3"
@@ -2137,12 +2162,25 @@
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz#70a62be213e1edc04bb8897ee48c311482f9700d"
   integrity sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==
 
+"@octokit/plugin-request-log@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
+  integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
+
 "@octokit/plugin-rest-endpoint-methods@4.13.5":
   version "4.13.5"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.13.5.tgz#ad76285b82fe05fbb4adf2774a9c887f3534a880"
   integrity sha512-kYKcWkFm4Ldk8bZai2RVEP1z97k1C/Ay2FN9FNTBg7JIyKoiiJjks4OtT6cuKeZX39tqa+C3J9xeYc6G+6g8uQ==
   dependencies:
     "@octokit/types" "^6.12.2"
+    deprecation "^2.3.1"
+
+"@octokit/plugin-rest-endpoint-methods@^5.12.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz#8c46109021a3412233f6f50d28786f8e552427ba"
+  integrity sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==
+  dependencies:
+    "@octokit/types" "^6.34.0"
     deprecation "^2.3.1"
 
 "@octokit/request-error@^1.0.1", "@octokit/request-error@^1.0.2":
@@ -2162,6 +2200,15 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
+"@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
 "@octokit/request@^5.0.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.2.0.tgz#5d3144ad921a8a6bc26d40dd542f2b62cfe3f3b7"
@@ -2175,7 +2222,7 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
-"@octokit/request@^5.2.0", "@octokit/request@^5.3.0":
+"@octokit/request@^5.3.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.3.1.tgz#3a1ace45e6f88b1be4749c5da963b3a3b4a2f120"
   integrity sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==
@@ -2203,23 +2250,17 @@
     once "^1.4.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@16.36.0":
-  version "16.36.0"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.36.0.tgz#99892c57ba632c2a7b21845584004387b56c2cb7"
-  integrity sha512-zoZj7Ya4vWBK4fjTwK2Cnmu7XBB1p9ygSvTk2TthN6DVJXM4hQZQoAiknWFLJWSTix4dnA3vuHtjPZbExYoCZA==
+"@octokit/request@^5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.3.tgz#19a022515a5bba965ac06c9d1334514eb50c48b0"
+  integrity sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==
   dependencies:
-    "@octokit/request" "^5.2.0"
-    "@octokit/request-error" "^1.0.2"
-    atob-lite "^2.0.0"
-    before-after-hook "^2.0.0"
-    btoa-lite "^1.0.0"
-    deprecation "^2.0.0"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
-    lodash.uniq "^4.5.0"
-    octokit-pagination-methods "^1.1.0"
-    once "^1.4.0"
-    universal-user-agent "^4.0.0"
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.7"
+    universal-user-agent "^6.0.0"
 
 "@octokit/rest@^16.15.0":
   version "16.33.0"
@@ -2249,6 +2290,16 @@
     "@octokit/plugin-request-log" "^1.0.2"
     "@octokit/plugin-rest-endpoint-methods" "4.13.5"
 
+"@octokit/rest@^18.12.0":
+  version "18.12.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
+  integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==
+  dependencies:
+    "@octokit/core" "^3.5.1"
+    "@octokit/plugin-paginate-rest" "^2.16.8"
+    "@octokit/plugin-request-log" "^1.0.4"
+    "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
+
 "@octokit/types@^2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.0.2.tgz#0888497f5a664e28b0449731d5e88e19b2a74f90"
@@ -2262,6 +2313,13 @@
   integrity sha512-kCkiN8scbCmSq+gwdJV0iLgHc0O/GTPY1/cffo9kECu1MvatLPh9E+qFhfRIktKfHEA6ZYvv6S1B4Wnv3bi3pA==
   dependencies:
     "@octokit/openapi-types" "^5.3.2"
+
+"@octokit/types@^6.16.1", "@octokit/types@^6.34.0":
+  version "6.34.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.34.0.tgz#c6021333334d1ecfb5d370a8798162ddf1ae8218"
+  integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==
+  dependencies:
+    "@octokit/openapi-types" "^11.2.0"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
@@ -7509,6 +7567,13 @@ node-fetch@^2.3.0, node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-gyp@^5.0.2:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.0.5.tgz#f6cf1da246eb8c42b097d7cd4d6c3ce23a4163af"
@@ -10045,6 +10110,11 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -10449,6 +10519,11 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -10524,6 +10599,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.4.0:
   version "8.4.0"


### PR DESCRIPTION
Update Octokit to latest and add new parameter for GitHub automatic release notes generation.

New input param `auto_generate_release_notes`. If `true`, GitHub will automatically generate release notes.

Closes #312 