### PR TITLE
Update Github Runner Node version and deprecate set-output

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,8 +21,8 @@ jobs:
           lfs: true
           fetch-depth: 0
 
-      - id: "yarn-cache"
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - id: yarn-cache
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: "actions/cache@v2.1.6"
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -19,8 +19,8 @@ jobs:
           lfs: true
           fetch-depth: 0
 
-      - id: "yarn-cache"
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - id: yarn-cache
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: "actions/cache@v2.1.6"
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,8 @@ jobs:
           lfs: true
           fetch-depth: 0
 
-      - id: "yarn-cache"
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - id: yarn-cache
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: "actions/cache@v2.1.6"
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}

--- a/packages/automatic-releases/action.yml
+++ b/packages/automatic-releases/action.yml
@@ -28,7 +28,7 @@ outputs:
   upload_url:
     description: "The URL for uploading additional assets to the release"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "git-merge"

--- a/packages/automatic-releases/package.json
+++ b/packages/automatic-releases/package.json
@@ -20,7 +20,7 @@
     "lintfix:prettier": "prettier --color --write $npm_package_config_prettierPaths"
   },
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.10.0",
     "@actions/github": "2.0.0",
     "@octokit/rest": "16.36.0",
     "conventional-changelog-angular": "^5.0.12",

--- a/packages/aws-ssm-secrets/action.yml
+++ b/packages/aws-ssm-secrets/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "The corresponding environment variable name to assign the secret to"
     required: true
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "lock"

--- a/packages/aws-ssm-secrets/package.json
+++ b/packages/aws-ssm-secrets/package.json
@@ -18,7 +18,7 @@
     "lintfix:prettier": "prettier --color --write $npm_package_config_prettierPaths"
   },
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.10.0",
     "aws-sdk": "^2.892.0"
   },
   "main": "dist/index.js",

--- a/packages/keybase-notifications/action.yml
+++ b/packages/keybase-notifications/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: "always"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "message-square"

--- a/packages/keybase-notifications/package.json
+++ b/packages/keybase-notifications/package.json
@@ -18,7 +18,7 @@
     "lintfix:prettier": "prettier --color --write $npm_package_config_prettierPaths"
   },
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.10.0",
     "@actions/github": "2.0.0",
     "axios": "^0.21.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,13 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.2.6":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.4.0.tgz#cf2e6ee317e314b03886adfeb20e448d50d6e524"
-  integrity sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg==
+"@actions/core@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.10.0.tgz#44551c3c71163949a2f06e94d9ca2157a0cfac4f"
+  integrity sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==
+  dependencies:
+    "@actions/http-client" "^2.0.1"
+    uuid "^8.3.2"
 
 "@actions/github@2.0.0":
   version "2.0.0"
@@ -14,6 +17,13 @@
   dependencies:
     "@octokit/graphql" "^4.3.1"
     "@octokit/rest" "^16.15.0"
+
+"@actions/http-client@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-2.0.1.tgz#873f4ca98fe32f6839462a6f046332677322f99c"
+  integrity sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==
+  dependencies:
+    tunnel "^0.0.6"
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -10095,6 +10105,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tunnel@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -10350,7 +10365,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
Update Runner Node version. Resolves: https://github.com/marvinpinto/actions/issues/543
Remove deprecated set-output command. Resolves: https://github.com/marvinpinto/actions/issues/544
[bump @actions/core from 1.4.0 to 1.10.0](https://github.com/marvinpinto/actions/pull/546/commits/4c7a8e059f62336d64cf50dd471cd6afc424529a) to resolve set-output issues in dependencies. 