### PR TITLE
docs(automatic-releases): Update example syntax

### DIFF
--- a/packages/automatic-releases/README.md
+++ b/packages/automatic-releases/README.md
@@ -50,7 +50,7 @@ jobs:
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: "latest"
           prerelease: true
           title: "Development Build"
@@ -91,7 +91,7 @@ jobs:
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
           files: |
             LICENSE.txt


### PR DESCRIPTION
I've recently run into issues when using the `marvinpinto/action-automatic-releases` action with "Input required and not supplied: repo_token" errors.

The full error is as follows:

<details>
<summary>Full Input required error message</summary>
Run marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
Error: Input required and not supplied: repo_token
(node:10778) UnhandledPromiseRejectionWarning: Error: Input required and not supplied: repo_token
    at Object.f [as getInput] (/home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:12178)
    at /home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:214236
    at /home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:214597
    at Generator.next (<anonymous>)
    at /home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:212886
    at new Promise (<anonymous>)
    at s (/home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:212631)
    at Object.t.main (/home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:214[16](https://github.com/jjliggett/jjversion-gha-output/actions/runs/3453868671/jobs/5764795471#step:29:17)1)
    at Object.<anonymous> (/home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b[17](https://github.com/jjliggett/jjversion-gha-output/actions/runs/3453868671/jobs/5764795471#step:29:18)9569b7a6fb4d8860689ab7f0/dist/index.js:1:212004)
    at r (/home/runner/work/_actions/marvinpinto/action-automatic-releases/919008cf3f741b179569b7a6fb4d8860689ab7f0/dist/index.js:1:124)
(node:10778) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:10778) [DEP00[18](https://github.com/jjliggett/jjversion-gha-output/actions/runs/3453868671/jobs/5764795471#step:29:19)] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
</details>

I tested changing the syntax in my workflow and removing the quotes around the repository token resolved the issue.

The original syntax had worked before, but I believe the syntax with quotes around the token is not functional now. I do not know why the original syntax broke.

Here is the pull request with the syntax change in my repository: https://github.com/jjliggett/jjversion-gha-output/pull/36
