### PR TITLE
Updating node version to 16

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -21,6 +21,11 @@ jobs:
           lfs: true
           fetch-depth: 0
 
+      - name: Use Node.js Own version
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+
       - id: "yarn-cache"
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: "actions/cache@v2.1.6"

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -19,6 +19,11 @@ jobs:
           lfs: true
           fetch-depth: 0
 
+      - name: Use Node.js Own version
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+
       - id: "yarn-cache"
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: "actions/cache@v2.1.6"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,11 @@ jobs:
           lfs: true
           fetch-depth: 0
 
+      - name: Use Node.js Own version
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+
       - id: "yarn-cache"
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: "actions/cache@v2.1.6"

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/gallium

--- a/packages/automatic-releases/action.yml
+++ b/packages/automatic-releases/action.yml
@@ -28,7 +28,7 @@ outputs:
   upload_url:
     description: "The URL for uploading additional assets to the release"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "git-merge"

--- a/packages/aws-ssm-secrets/action.yml
+++ b/packages/aws-ssm-secrets/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "The corresponding environment variable name to assign the secret to"
     required: true
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "lock"

--- a/packages/keybase-notifications/action.yml
+++ b/packages/keybase-notifications/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: "always"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "message-square"


### PR DESCRIPTION
Github is issuing some warnings when using this task due to the node version: 

`Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: marvinpinto/action-inject-ssm-secrets@latest. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
`

I merely updated the node version to 16 and ran the tests, everything seems to be working fine.

Thanks a lot for this action @marvinpinto 